### PR TITLE
Fix barcodeHandler retain cycle

### DIFF
--- a/Example/AVScanner/ViewController.swift
+++ b/Example/AVScanner/ViewController.swift
@@ -35,7 +35,9 @@ class ViewController: AVScannerViewController {
     // MARK: - Prepare viewDidLoad
     
     private func prepareBarcodeHandler () {
-        barcodeHandler = barcodeDidCaptured
+        barcodeHandler = { (barcodeString) in
+            print("barcode did captured: \(barcodeString)")
+        }
     }
     
     private func prepareViewTapHandler() {
@@ -44,11 +46,6 @@ class ViewController: AVScannerViewController {
     }
     
     // MAKR: - AVScanner view handler
-    
-    func barcodeDidCaptured(barcodeString: String) {
-        print("barcode did captured: \(barcodeString)")
-    }
-    
     func viewTapHandler(_ gesture: UITapGestureRecognizer) {
         guard !isSessionRunning else { return }
         startRunningSession()


### PR DESCRIPTION
happened when assigning `barcodeDidCaptured` function `(special cases of closures)` to `barcodeHandler` closure. 

there is a good article discuss about this pass-function-to-closure thing: 
> reference to an instance function means that you're referencing the instance as well. And thus when assigning to a variable, you're creating a strong reference.

http://blog.xebia.com/function-references-in-swift-and-retain-cycles/

p.s. awesome work of animation!